### PR TITLE
Removed references to net.rim.vm in Widget.java

### DIFF
--- a/framework/src/blackberry/web/widget/Widget.java
+++ b/framework/src/blackberry/web/widget/Widget.java
@@ -137,12 +137,14 @@ public class Widget extends UiApplication implements GlobalEventListener {
         // use ApplicationManager.waitForStartup() in 6.0 when it's available
         ApplicationManager manager = ApplicationManager.getApplicationManager();
         while(manager.inStartup()) {
-            net.rim.vm.Process.waitForIdle();
             try {
                 Thread.sleep(2000);
             } catch(InterruptedException e) {}
         }
-        net.rim.vm.Process.waitForIdle(30000);        
+        
+        try {
+            Thread.sleep(1500);
+        } catch(InterruptedException e) {}        
     }
     
     private static void makeDebugArgs(String[] args,WidgetConfigImpl wConfig) {


### PR DESCRIPTION
The code was replaced with what was found in the Web Plug-in for Eclipse 2.5.  This is assuming that we will not have net.rim.vm available to us for compilation.
