### PR TITLE
Packager Support for Linux and Mac OS X

### DIFF
--- a/packager/src/net/rim/tumbler/CmdLineHandler.java
+++ b/packager/src/net/rim/tumbler/CmdLineHandler.java
@@ -24,9 +24,11 @@ import net.rim.tumbler.exception.CommandLineException;
 import net.rim.tumbler.exception.PackageException;
 import net.rim.tumbler.log.LogType;
 import net.rim.tumbler.log.Logger;
+import net.rim.tumbler.os.OperatingSystems;
 import net.rim.tumbler.session.SessionManager;
 
 public class CmdLineHandler {
+    private static final String         EXE_SUFFIX = ".exe";
     private static final String         FILE_SEP = System.getProperty("file.separator");
     private static final String         OPTION_SOURCEDIR = "/s";
     private static final String         OPTION_PASSWORD = "/g";    
@@ -120,6 +122,11 @@ public class CmdLineHandler {
     }
       
     private String getAbsolutePath(String filePath) {
+        
+        if( !OperatingSystems.isWindows() && filePath.endsWith( EXE_SUFFIX )){
+            filePath = filePath.replace( EXE_SUFFIX, "" );
+        }
+        
         try {
             return (new File(filePath)).getCanonicalFile().getAbsolutePath();
         } catch (Exception e) {
@@ -182,7 +189,13 @@ public class CmdLineHandler {
 
         // Populate correct source directory
         if (!_requireSource) {
-            _sourceDir = System.getProperty("java.io.tmpdir") + "widgetGen."
+            String tmpDir = System.getProperty("java.io.tmpdir");
+            if( !tmpDir.endsWith( "/" ) && !OperatingSystems.isWindows() ) {
+                // we probably won't have permissions to create a new top-level directory, so ensure the generated _sourceDir is under the existing tmpDir.
+                tmpDir += "/";
+            }
+            
+            _sourceDir = tmpDir + "widgetGen."
                     + new Random().nextInt(2147483647) + new Date().getTime()
                     + ".tmp";
         } else {

--- a/packager/src/net/rim/tumbler/CmdLineHandler.java
+++ b/packager/src/net/rim/tumbler/CmdLineHandler.java
@@ -190,9 +190,9 @@ public class CmdLineHandler {
         // Populate correct source directory
         if (!_requireSource) {
             String tmpDir = System.getProperty("java.io.tmpdir");
-            if( !tmpDir.endsWith( "/" ) && !OperatingSystems.isWindows() ) {
+            if( !tmpDir.endsWith( File.separator ) && !OperatingSystems.isWindows() ) {
                 // we probably won't have permissions to create a new top-level directory, so ensure the generated _sourceDir is under the existing tmpDir.
-                tmpDir += "/";
+                tmpDir += File.separator;
             }
             
             _sourceDir = tmpDir + "widgetGen."

--- a/packager/src/net/rim/tumbler/WidgetPackager.java
+++ b/packager/src/net/rim/tumbler/WidgetPackager.java
@@ -27,6 +27,7 @@ import net.rim.tumbler.exception.ValidationException;
 import net.rim.tumbler.file.FileManager;
 import net.rim.tumbler.log.LogType;
 import net.rim.tumbler.log.Logger;
+import net.rim.tumbler.os.OperatingSystems;
 import net.rim.tumbler.rapc.Rapc;
 import net.rim.tumbler.serialize.WidgetConfigSerializer;
 import net.rim.tumbler.serialize.WidgetConfig_v1Serializer;
@@ -187,6 +188,10 @@ public class WidgetPackager {
 					+ "\"" + sessionManager.getSourceFolder()
 					+ System.getProperty("file.separator")
 					+ sessionManager.getArchiveName() + ".cod" + "\"";
+			if( !OperatingSystems.isWindows() ) {
+			    cmdline = cmdline.replace( "\"", "" );
+			}
+			
 			signingProcess = Runtime.getRuntime().exec(cmdline, null, cwd);
 		} catch (IOException ex) {
 			throw ex;

--- a/packager/src/net/rim/tumbler/os/OperatingSystems.java
+++ b/packager/src/net/rim/tumbler/os/OperatingSystems.java
@@ -1,0 +1,18 @@
+package net.rim.tumbler.os;
+
+/**
+ * Utility methods for determining the running operating system.
+ */
+public final class OperatingSystems {
+
+    /**
+     * Determines whether the running operating system is a Microsoft Windows OS.
+     * 
+     * @return true if the <code>os.name</code> system property contains "win".
+     */
+    public static final boolean isWindows() {
+
+        String osName = System.getProperty( "os.name" ).toLowerCase();
+        return osName.contains( "win" ) && !osName.contains( "darwin" );
+    }
+}

--- a/packager/src/net/rim/tumbler/rapc/Rapc.java
+++ b/packager/src/net/rim/tumbler/rapc/Rapc.java
@@ -494,10 +494,7 @@ public class Rapc {
     // / </summary>
     private String getJavaBin(String javaHome) {
     	if(javaHome != null && !javaHome.trim().isEmpty()) {
-    	    if( OperatingSystems.isWindows() ) {
-    	        return javaHome + "\\bin";
-    	    }
-    	    return javaHome + "/bin";
+    	    return javaHome + File.separator + "bin";
     	}
     	
     	return "";

--- a/packager/src/net/rim/tumbler/session/BBWPProperties.java
+++ b/packager/src/net/rim/tumbler/session/BBWPProperties.java
@@ -195,13 +195,7 @@ public class BBWPProperties {
                                 if (new File(_rapc).isAbsolute()) {
                                     _rapc = getAbsolutePath(_rapc);
                                 } else {
-                                    
-                                    if( OperatingSystems.isWindows() ) {
-                                        _rapc = _sessionHome + "\\" + _rapc;
-                                    }
-                                    else{
-                                        _rapc = _sessionHome + "/" + _rapc;
-                                    }
+                                    _rapc = _sessionHome + File.separator + _rapc;
                                 }
                             }
                         }
@@ -215,13 +209,7 @@ public class BBWPProperties {
                                 if (new File(_preverifyDirectory).isAbsolute()) {
                                     _preverifyDirectory = getAbsolutePath(_preverifyDirectory);
                                 } else {
-                                    
-                                    if( OperatingSystems.isWindows() ) {
-                                        _preverifyDirectory = _sessionHome + "\\" + _preverifyDirectory;
-                                    }
-                                    else{
-                                        _preverifyDirectory = _sessionHome + "/" + _preverifyDirectory;
-                                    }
+                                    _preverifyDirectory = _sessionHome + File.separator + _preverifyDirectory;
                                 }
                             }
                         }
@@ -234,12 +222,9 @@ public class BBWPProperties {
 
                             if (!_javaHome.isEmpty()) {
                                 
+                                _javac = _javaHome + File.separator + "bin" + File.separator + "javac";
                                 if( OperatingSystems.isWindows() ) {
-                                    _javac = "\"" + _javaHome + "\\bin\\javac.exe"
-                                            + "\"";
-                                }
-                                else {
-                                    _javac = _javaHome + "/bin/javac";
+                                    _javac = "\"" + _javac + ".exe\"";
                                 }
                             } else {
                                 _javac = getAbsolutePath("javac.exe");
@@ -255,12 +240,7 @@ public class BBWPProperties {
                             if (new File(_templateDir).isAbsolute()) {
                                 _templateDir = getAbsolutePath(_templateDir);
                             } else {
-                                if( OperatingSystems.isWindows() ) {
-                                    _templateDir = _sessionHome + "\\" + _templateDir;
-                                }
-                                else{
-                                    _templateDir = _sessionHome + "/" + _templateDir;
-                                }
+                                _templateDir = _sessionHome + File.separator + _templateDir;
                             }
                         }
                     }
@@ -287,12 +267,7 @@ public class BBWPProperties {
                             if (new File(_repositoryDir).isAbsolute()) {
                             	_repositoryDir = getAbsolutePath(_repositoryDir);
                             } else {
-                                if( OperatingSystems.isWindows() ) {
-                                    _repositoryDir = _sessionHome + "\\" + _repositoryDir;
-                                }
-                                else{
-                                    _repositoryDir = _sessionHome + "/" + _repositoryDir;
-                                }
+                                _repositoryDir = _sessionHome + File.separator + _repositoryDir;
                             }
                         }
                     }                	
@@ -318,12 +293,7 @@ public class BBWPProperties {
             if (new File(lib).isAbsolute()) {
                 lib = getAbsolutePath(lib);
             } else {
-                if( OperatingSystems.isWindows() ) {
-                    lib = _sessionHome + "\\" + lib;
-                }
-                else{
-                    lib = _sessionHome + "/" + lib;
-                }
+                lib = _sessionHome + File.separator + lib;
             }
             
             if (new File(lib).exists()) {

--- a/packager/src/net/rim/tumbler/session/BBWPProperties.java
+++ b/packager/src/net/rim/tumbler/session/BBWPProperties.java
@@ -22,6 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import net.rim.tumbler.exception.PackageException;
+import net.rim.tumbler.exception.ValidationException;
+import net.rim.tumbler.os.OperatingSystems;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -29,12 +33,10 @@ import org.xml.sax.InputSource;
 
 import com.sun.org.apache.xerces.internal.parsers.DOMParser;
 
-import net.rim.tumbler.exception.PackageException;
-import net.rim.tumbler.exception.ValidationException;
-
 public class BBWPProperties {
     private static final String NODE_WCP = "wcp";
     private static final String NODE_JAVA = "java";
+    private static final String NODE_PREVERIFY_DIRECTORY = "preverify_directory";
     private static final String NODE_RAPC = "rapc";
     private static final String NODE_JAR = "jar";
     private static final String NODE_TEMPLATE = "wcp_template";
@@ -42,6 +44,7 @@ public class BBWPProperties {
     private static final String NODE_REPOSITORY = "extension_repository";
     
     private String          _rapc;
+    private String          _preverifyDirectory;
     private String          _javac;
     private String          _templateDir;
     private List<String>    _imports;
@@ -63,6 +66,10 @@ public class BBWPProperties {
     
     public String getRapc() {
         return _rapc;
+    }
+    
+    public String getPreverifyDirectory() {
+        return _preverifyDirectory;
     }
 
     public String getJavac() {
@@ -187,8 +194,34 @@ public class BBWPProperties {
                             if (!_rapc.equals("rapc.exe") && !_rapc.equals("rapc")) {
                                 if (new File(_rapc).isAbsolute()) {
                                     _rapc = getAbsolutePath(_rapc);
-                                } else {                                
-                                    _rapc = _sessionHome + "\\" + _rapc;
+                                } else {
+                                    
+                                    if( OperatingSystems.isWindows() ) {
+                                        _rapc = _sessionHome + "\\" + _rapc;
+                                    }
+                                    else{
+                                        _rapc = _sessionHome + "/" + _rapc;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if (nodename.equals(NODE_PREVERIFY_DIRECTORY)) {
+                    NodeList childlist = node.getChildNodes();
+                    for (int j = 0; j < childlist.getLength(); j++) {
+                        if (childlist.item(j).getNodeType() == Node.TEXT_NODE) {
+                            _preverifyDirectory = childlist.item(j).getNodeValue();
+                            if (!_preverifyDirectory.equals("preverify.exe") && !_preverifyDirectory.equals("preverify")) {
+                                if (new File(_preverifyDirectory).isAbsolute()) {
+                                    _preverifyDirectory = getAbsolutePath(_preverifyDirectory);
+                                } else {
+                                    
+                                    if( OperatingSystems.isWindows() ) {
+                                        _preverifyDirectory = _sessionHome + "\\" + _preverifyDirectory;
+                                    }
+                                    else{
+                                        _preverifyDirectory = _sessionHome + "/" + _preverifyDirectory;
+                                    }
                                 }
                             }
                         }
@@ -200,8 +233,14 @@ public class BBWPProperties {
                             _javaHome = childlist.item(j).getNodeValue();
 
                             if (!_javaHome.isEmpty()) {
-                                _javac = "\"" + _javaHome + "\\bin\\javac.exe"
-                                        + "\"";
+                                
+                                if( OperatingSystems.isWindows() ) {
+                                    _javac = "\"" + _javaHome + "\\bin\\javac.exe"
+                                            + "\"";
+                                }
+                                else {
+                                    _javac = _javaHome + "/bin/javac";
+                                }
                             } else {
                                 _javac = getAbsolutePath("javac.exe");
                             }
@@ -216,7 +255,12 @@ public class BBWPProperties {
                             if (new File(_templateDir).isAbsolute()) {
                                 _templateDir = getAbsolutePath(_templateDir);
                             } else {
-                                _templateDir = _sessionHome + "\\" + _templateDir;
+                                if( OperatingSystems.isWindows() ) {
+                                    _templateDir = _sessionHome + "\\" + _templateDir;
+                                }
+                                else{
+                                    _templateDir = _sessionHome + "/" + _templateDir;
+                                }
                             }
                         }
                     }
@@ -243,7 +287,12 @@ public class BBWPProperties {
                             if (new File(_repositoryDir).isAbsolute()) {
                             	_repositoryDir = getAbsolutePath(_repositoryDir);
                             } else {
-                            	_repositoryDir = _sessionHome + "\\" + _repositoryDir;
+                                if( OperatingSystems.isWindows() ) {
+                                    _repositoryDir = _sessionHome + "\\" + _repositoryDir;
+                                }
+                                else{
+                                    _repositoryDir = _sessionHome + "/" + _repositoryDir;
+                                }
                             }
                         }
                     }                	
@@ -269,7 +318,12 @@ public class BBWPProperties {
             if (new File(lib).isAbsolute()) {
                 lib = getAbsolutePath(lib);
             } else {
-                lib = _sessionHome + "\\" + lib;
+                if( OperatingSystems.isWindows() ) {
+                    lib = _sessionHome + "\\" + lib;
+                }
+                else{
+                    lib = _sessionHome + "/" + lib;
+                }
             }
             
             if (new File(lib).exists()) {

--- a/packager/src/net/rim/tumbler/session/SessionManager.java
+++ b/packager/src/net/rim/tumbler/session/SessionManager.java
@@ -26,7 +26,6 @@ import net.rim.tumbler.WidgetPackager;
 import net.rim.tumbler.exception.PackageException;
 import net.rim.tumbler.exception.SessionException;
 import net.rim.tumbler.exception.ValidationException;
-import net.rim.tumbler.os.OperatingSystems;
 
 public class SessionManager {
     private static SessionManager _instance = null;
@@ -171,13 +170,8 @@ public class SessionManager {
             return System.getProperty("user.dir");
         } else {
             
-            if( OperatingSystems.isWindows() ) {
-                return home
-                        .substring(0, home.lastIndexOf("\\bin"));
-            }
-            
             return home
-                .substring(0, home.lastIndexOf("/bin"));
+                .substring(0, home.lastIndexOf(File.separator + "bin"));
         }
     }
     

--- a/packager/src/net/rim/tumbler/session/SessionManager.java
+++ b/packager/src/net/rim/tumbler/session/SessionManager.java
@@ -26,6 +26,7 @@ import net.rim.tumbler.WidgetPackager;
 import net.rim.tumbler.exception.PackageException;
 import net.rim.tumbler.exception.SessionException;
 import net.rim.tumbler.exception.ValidationException;
+import net.rim.tumbler.os.OperatingSystems;
 
 public class SessionManager {
     private static SessionManager _instance = null;
@@ -169,8 +170,14 @@ public class SessionManager {
         if (home.equals("")) {
             return System.getProperty("user.dir");
         } else {
+            
+            if( OperatingSystems.isWindows() ) {
+                return home
+                        .substring(0, home.lastIndexOf("\\bin"));
+            }
+            
             return home
-                    .substring(0, home.lastIndexOf("\\bin"));
+                .substring(0, home.lastIndexOf("/bin"));
         }
     }
     


### PR DESCRIPTION
I've modified the packager to support execution on Linux and Mac OS X.  It fixes folder separators and file paths for non-Windows OSes.

Since Linux and Mac users won't be able to use the preverify tool currently included with the installer for "Command Line Tools for BlackBerry Smartphone Apps", I have also added support to BBWPProperties for a "preverify_directory" value (this should be the path to the directory which contains the preverify executable).
