### PR TITLE
Fixed README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# About BlackBerry&reg; WebWorks
+# About BlackBerry&reg; WebWorks&trade;
+
 The BlackBerry&reg; WebWorks&trade; for the BlackBerry Smartphone OS allows web and mobile web developers to use the SDK in combination with their development 
 tooling of choice to develop, test and package up their web applications as BlackBerry WebWorks applications for smartphones. 
 BlackBerry WebWorks applications can be distributed through the BlackBerry App World&trade; storefront and they run on the BlackBerry&reg; Smartphones 
 with access to the hardware.
 
-The project is Open Sourced under the Apache 2.0 license [http://github.com/blackberry](http://github.com/blackberry).
+The project is open source under the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license.
 
 * Advanced Standards
 * Powerful Integration
 * Open
  
-[Read more](https://github.com/blackberry/WebWorks/wiki) about the BlackBerry WebWorks open source project
+[Read more](http://blackberry.github.com/webworks/index.html) about the BlackBerry WebWorks open source project
 
 ## Downloads
 Full installers for Windows can be found on the [product download page](http://us.blackberry.com/developers/browserdev/widgetsdk.jsp)
@@ -18,7 +19,7 @@ Full installers for Windows can be found on the [product download page](http://u
 ## Reference Material &amp; Community
 You can also find associated reference material for the BlackBerry WebWorks platform as well as community forums for building and contributing to the BlackBerry WebWorks project
 
-* [API Reference](http://www.blackberry.com/developers/docs/widgetapi/)
+* [API Reference](http://www.blackberry.com/developers/docs/webworks/api/)
 * [Developer Guides](http://docs.blackberry.com/en/developers/subcategories/?userType=21&category=BlackBerry+Widgets&subCategory=BlackBerry+Widget+Development+Guides)
 * [Community Forums](http://supportforums.blackberry.com/t5/Web-Development/bd-p/browser_dev)
 * [Project Contributor Forums](http://supportforums.blackberry.com/t5/BlackBerry-WebWorks/bd-p/ww_con)


### PR DESCRIPTION
The old readme file was pointing to the repo-based wiki for WebWorks.  This updated one now has the links to the blackberry.github.com pages
